### PR TITLE
Follow-up Process now acceptable from signuppages

### DIFF
--- a/src/LassoLead.php
+++ b/src/LassoLead.php
@@ -85,6 +85,11 @@ class LassoLead
   private $sourceType = 'Online Registration';
 
   /**
+   * String $followUpProcess
+   */
+  private $followUpProcess = '';
+
+  /**
    * @param String $firstName
    */
   public function setFirstName($firstName) {
@@ -186,6 +191,13 @@ class LassoLead
    */
   public function setSourceType($sourceType) {
       $this->sourceType = $sourceType;
+  }
+
+  /**
+   * @param String $followUpProcess
+   */
+  public function setFollowUpProcess($followUpProcess) {
+      $this->followUpProcess = $followUpProcess;
   }
 
   /**


### PR DESCRIPTION
- LAS-8008
- Case sensitivity is not required to match a follow up process,
  but the string must exist in the project's list of follow up
  processes for the match to happen
