### PR TITLE
Update zapier py integration doc w/ hardcode vars

### DIFF
--- a/src/registrant-submitter-zapier.py
+++ b/src/registrant-submitter-zapier.py
@@ -2,14 +2,21 @@ import requests
 
 clientId = input_data['clientID']
 projectId = input_data['projectID']
+# alternatively, if clientId and projectId are not passed in as input, they can be hardcoded like this:
+# clientId = '123'
+# projectId = '456'
 
 url = 'https://api.lassocrm.com/registrants'
+
 headers = {'X-Lasso-Auth': 'Token=' + input_data['LassoUID'] + ', Version=1.0'}
+# alternatively, if  the auth token is not passed in as input, it can be hardcoded like this:
+# headers = {'X-Lasso-Auth': 'Token=fgxb2rq, Version=1.0'}
+
 json = {
     'firstName': input_data['firstName'], 
     'lastName': input_data['lastName'],
-    'clientId': input_data['clientID'], 
-    'projectIds': [input_data['projectID']], 
+    'clientId': clientId,
+    'projectIds': [projectId],
     'emails': [
         {
             'email': input_data['email'],


### PR DESCRIPTION
- some clients won't pass in clientId, projectId, and the auth token
  through as input
- an example of how we might hardcode these values are now included
- clients were having trouble specifically trying to get around the string
  concatenation in headers
