### PR TITLE
Added option to disable SSL verifier

### DIFF
--- a/src/RegistrantSubmitter.php
+++ b/src/RegistrantSubmitter.php
@@ -11,6 +11,8 @@ class RegistrantSubmitter
     curl_setopt($curl, CURLOPT_URL, $location);
     curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($lead->toArray()));
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    // Uncomment the code below if website does not have SSL certificate
+    //curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
     curl_setopt($curl, CURLOPT_HTTPHEADER, array(
       'Content-Type: application/json',
       'X-Lasso-Auth:'. 'Token='. $apiKey . ',Version=1.0',


### PR DESCRIPTION
- The added code is currently commented out.
- User can un-comment the code if needed (i.e. if the website does not have SSL certificate)